### PR TITLE
Adds callback for enabling foreign key constraints

### DIFF
--- a/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/db/MechanoidSQLiteOpenHelper.java
+++ b/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/db/MechanoidSQLiteOpenHelper.java
@@ -28,10 +28,11 @@ public abstract class MechanoidSQLiteOpenHelper extends SQLiteOpenHelper {
         	// Enable foreign key constraints
         	if (db.isReadOnly() || !shouldEnableForeignKeyConstraints())
         		return;
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO)
-    			db.execSQL("PRAGMA foreign_keys=ON;");
-    		else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN)
+		
+    		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN)
     			db.setForeignKeyConstraintsEnabled(true);
+    		else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO)
+    			db.execSQL("PRAGMA foreign_keys=ON;");
     	}
 
 	@Override


### PR DESCRIPTION
proposed in https://github.com/robotoworks/mechanoid/issues/76 

This way the default behavior is unchanged, but if one wanted to enable foreign key constraints they simply need to override `shouldEnableForeignKeyConstraints` in their open helper. It applies the proper version gating to do the right thing based on the device it's running on.
