### PR TITLE
fixed checking for custom response code

### DIFF
--- a/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/net/Response.java
+++ b/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/net/Response.java
@@ -106,7 +106,7 @@ public class Response<T> {
 	 * on the response code to ensure its of a certain code before continuing</p>
 	 */
 	public void checkResponseCode(int responseCode) throws UnexpectedHttpStatusException {
-		if(mResponseCode != HTTP_OK) {
+		if(mResponseCode != responseCode) {
 			throw new UnexpectedHttpStatusException(mResponseCode, HTTP_OK);
 		}
 	}


### PR DESCRIPTION
Seems to be a copy/paste issue: Response#checkResponseCode(int) should actually use the provided response code, rather than checking only for HTTP_OK
