### PR TITLE
refactored retrieving of inputstream

### DIFF
--- a/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/net/Response.java
+++ b/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/net/Response.java
@@ -163,11 +163,13 @@ public class Response<T> {
 	}
 
 	private InputStream getInputStream() throws IOException {
-		if(mResponseCode == 200) {
-			return mConn.getInputStream();
-		} else {
-			return mConn.getErrorStream();
-		}
+		// error stream is available only if there was a connection with the 
+		// server, the server returned an error and also returned some usefull 
+		// data. Example being status 404 with page to search for content.
+		stream = mConn.getErrorStream();
+		if (stream != null)
+			return stream;
+		return mConn.getInputStream();
 	}
 	
 	/**


### PR DESCRIPTION
**The problem**: http status codes 201, 202, etc. which are used in same APIs along with some useful response data, cannot be implemented.

**The digging**: _Response_ class tries to use connection's error stream in all cases except http status 200. As per [SO](http://stackoverflow.com/a/11526448/533873) the error stream is only available if there was a connection which resulted in exception and some data was received.

**The solution**: Two possibilities are available, implement the logic when the error stream is available or rely on it's availability. The second approach is implemented in the pull request.

**Some explanation**: The new code tries to use the error stream first, and if it is not available (no error happened) then uses the input stream. This approach relies on the connection to correctly return error stream only in the case where there was error.

**How to test**: Try to read the response from [this API](http://docs.mechtest.apiary.io/#post-%2Fnotes) 
