### PR TITLE
[MECHDB] Specified additional functions when infering type of column

### DIFF
--- a/plugins/com.robotoworks.mechanoid.db/src/com/robotoworks/mechanoid/db/util/ModelUtil.xtend
+++ b/plugins/com.robotoworks.mechanoid.db/src/com/robotoworks/mechanoid/db/util/ModelUtil.xtend
@@ -278,12 +278,29 @@ class ModelUtil {
 				return ColumnType::TEXT
 			}
 			Function: {
+				// function return types taken from http://www.sqlite.org/lang_corefunc.html and http://www.sqlite.org/lang_aggfunc.html
 				if(expr.name.equalsIgnoreCase("count") ||
 					expr.name.equalsIgnoreCase("length") ||
-					expr.name.equalsIgnoreCase("random")
+					expr.name.equalsIgnoreCase("random") ||
+					expr.name.equalsIgnoreCase("last_insert_rowid") ||
+					expr.name.equalsIgnoreCase("changes") ||
+					expr.name.equalsIgnoreCase("total_changes")
 				) {
 					return ColumnType::INTEGER
+				} else if (expr.name.equalsIgnoreCase("abs") ||
+					expr.name.equalsIgnoreCase("avg") ||
+					expr.name.equalsIgnoreCase("round") ||
+					expr.name.equalsIgnoreCase("sum") ||
+					expr.name.equalsIgnoreCase("total") ||
+					expr.name.equalsIgnoreCase("likelihood")
+				) {
+					return ColumnType::REAL
+				} else if (expr.name.equalsIgnoreCase("randomblob") ||
+					expr.name.equalsIgnoreCase("zeroblob")
+				) {
+					return ColumnType::BLOB
 				}
+
 				
 				return ColumnType::TEXT
 			}


### PR DESCRIPTION
When inferring type of column default is TEXT. I added the core and aggregate functions for which types is known so views like `select sum(val) as sum` will not generate the column `sum` as TEXT, but as FLOAT.

I haven't tried the code and haven't uploaded the generated ModelUtil.java file.
