### PR TITLE
Added support for group by expressions

### DIFF
--- a/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/db/DefaultContentProviderActions.java
+++ b/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/db/DefaultContentProviderActions.java
@@ -25,6 +25,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import android.provider.BaseColumns;
+import android.text.TextUtils;
 
 import com.robotoworks.mechanoid.util.Closeables;
 
@@ -130,6 +131,7 @@ public class DefaultContentProviderActions extends ContentProviderActions {
 	@Override
 	public Cursor query(MechanoidContentProvider provider, Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder){
 		final SQLiteDatabase db = provider.getOpenHelper().getWritableDatabase();
+		String groupBy = uri.getQueryParameter(MechanoidContentProvider.PARAM_GROUP_BY);
 		
 		if(mForUrisWithId) {
 			long id = ContentUris.parseId(uri);
@@ -137,9 +139,9 @@ public class DefaultContentProviderActions extends ContentProviderActions {
 			return SQuery.newQuery()
 				.expr(BaseColumns._ID, SQuery.Op.EQ, id)
 				.append(selection, selectionArgs)
-				.query(db, mSource, projection, sortOrder);
+				.query(db, mSource, projection, sortOrder, TextUtils.isEmpty(groupBy) ? null : groupBy);
 		} else {
-			return db.query(mSource, projection, selection, selectionArgs, null, null, sortOrder);
+			return db.query(mSource, projection, selection, selectionArgs, TextUtils.isEmpty(groupBy) ? null : groupBy, null, sortOrder);
 		}
 	}
 	
@@ -175,6 +177,7 @@ public class DefaultContentProviderActions extends ContentProviderActions {
 			return null;
 		}
 		
+		String groupBy = uri.getQueryParameter(MechanoidContentProvider.PARAM_GROUP_BY);
 		final SQLiteDatabase db = provider.getOpenHelper().getWritableDatabase();
 		
 		Cursor c = null;
@@ -182,7 +185,7 @@ public class DefaultContentProviderActions extends ContentProviderActions {
 		ArrayList<T> items = new ArrayList<T>();
 		
 		try {
-			c = db.query(mSource, mRecordFactory.getProjection(), sQuery.toString(), sQuery.getArgsArray(), null, null, sortOrder);
+			c = db.query(mSource, mRecordFactory.getProjection(), sQuery.toString(), sQuery.getArgsArray(), TextUtils.isEmpty(groupBy) ? null : groupBy, null, sortOrder);
 		    
 		    while(c.moveToNext()) {
 		        items.add((T)mRecordFactory.create(c));
@@ -202,7 +205,7 @@ public class DefaultContentProviderActions extends ContentProviderActions {
 		if(mRecordFactory == null) {
 			return null;
 		}
-		
+		String groupBy = uri.getQueryParameter(MechanoidContentProvider.PARAM_GROUP_BY);
 		final SQLiteDatabase db = provider.getOpenHelper().getWritableDatabase();
 		
 		Cursor c = null;
@@ -210,7 +213,7 @@ public class DefaultContentProviderActions extends ContentProviderActions {
 		HashMap<String, T> items = new HashMap<String, T>();
 		
 		try {
-			c = db.query(mSource, mRecordFactory.getProjection(), sQuery.toString(), sQuery.getArgsArray(), null, null, null);
+			c = db.query(mSource, mRecordFactory.getProjection(), sQuery.toString(), sQuery.getArgsArray(), TextUtils.isEmpty(groupBy) ? null : groupBy, null, null);
 		    int keyColumnIndex = c.getColumnIndexOrThrow(keyColumnName);
 		    
 		    while(c.moveToNext()) {

--- a/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/db/MechanoidContentProvider.java
+++ b/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/db/MechanoidContentProvider.java
@@ -39,6 +39,8 @@ import android.net.Uri;
 public abstract class MechanoidContentProvider extends ContentProvider {
 	
 	public static final String PARAM_NOTIFY = "mechdb_notify";
+
+	public static final String PARAM_GROUP_BY = "mechdb_group_by";
 	
     private MechanoidSQLiteOpenHelper mOpenHelper;
 


### PR DESCRIPTION
Hi.
First off I want to say that mechanoid is AWESOME , it really makes your life easier :+1: )

Second  I've been wondering why group by is not implemented in the select/createLoader methods , so here it is. I know that it can be specified in the .mechdb file when creating a view, but it can't be done in a sane way in the code.

Since the contentResolver / loader  does not  support groupBy in the parameters, i'm passing the group by clause with the URI as a query parameter to the ContentProvider.

Drop off a line if you have some critics or comments.

Best Regards,
Rangel
