### PR TITLE
Null-Check on Class from ServiceInfo (clz!=null)

### DIFF
--- a/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/ops/OperationServiceBridge.java
+++ b/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/ops/OperationServiceBridge.java
@@ -129,7 +129,7 @@ public class OperationServiceBridge {
 				
 				Class<?> clz = ReflectUtil.loadClassSilently(Ops.class.getClassLoader(), serviceName);
 
-				if(Service.class.isAssignableFrom(clz)) {
+				if(clz != null && Service.class.isAssignableFrom(clz)) {
 					Field field = ReflectUtil.getFieldSilently(clz, "CONFIG");
 					if(field != null) {
 						OperationServiceConfiguration factory = (OperationServiceConfiguration) ReflectUtil.getFieldValueSilently(field);


### PR DESCRIPTION
Class obtained from ServiceInfo can be null. For example while working with Amazon Device Messaging you cannot export a jar with this class (because it won't work on Kindle Fire then). While launching on non-Kindle devide this class is not really used (and application would work fine) but Mechanoid will throw NPE due to lack of this service Class.
