### PR TITLE
fixed wrong entity writer method name

### DIFF
--- a/plugins/com.robotoworks.mechanoid.net/src/com/robotoworks/mechanoid/net/generator/RequestGenerator.xtend
+++ b/plugins/com.robotoworks.mechanoid.net/src/com/robotoworks/mechanoid/net/generator/RequestGenerator.xtend
@@ -378,7 +378,7 @@ class RequestGenerator {
 	) '''
 		«imports.addImport("java.util.List")»
 		«generateSerializationStatementHeader(true)»
-			provider.get(«type.innerSignature».class).List(writer, «type.innerSignature.camelize.pluralize»);
+			provider.get(«type.innerSignature».class).writeList(writer, «type.innerSignature.camelize.pluralize»);
 		«generateSerializationStatementFooter(true)»
 	'''
 

--- a/plugins/com.robotoworks.mechanoid.net/xtend-gen/com/robotoworks/mechanoid/net/generator/RequestGenerator.java
+++ b/plugins/com.robotoworks.mechanoid.net/xtend-gen/com/robotoworks/mechanoid/net/generator/RequestGenerator.java
@@ -1212,7 +1212,7 @@ public class RequestGenerator {
     _builder.append("provider.get(");
     String _innerSignature = ModelExtensions.innerSignature(type);
     _builder.append(_innerSignature, "\t");
-    _builder.append(".class).List(writer, ");
+    _builder.append(".class).writeList(writer, ");
     String _innerSignature_1 = ModelExtensions.innerSignature(type);
     String _camelize = Strings.camelize(_innerSignature_1);
     String _pluralize = Strings.pluralize(_camelize);


### PR DESCRIPTION
Hi there,

I had a compile time error with generated mechanoid.net Request files.
It turned out that entity writer method name is not correctly typed in RequestGenerator.xtend.
