### PR TITLE
populate PendingRequests

### DIFF
--- a/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/ops/OperationServiceBridge.java
+++ b/libs/mechanoid/src/main/java/com/robotoworks/mechanoid/ops/OperationServiceBridge.java
@@ -51,7 +51,7 @@ public class OperationServiceBridge {
 	
 	private Hashtable<String, OperationServiceConfiguration> mConfigurations = new Hashtable<String, OperationServiceConfiguration>();
 	
-	private SparseArray<Intent> mPendingRequests = new SparseArray<Intent>();
+	private static SparseArray<Intent> mPendingRequests = new SparseArray<Intent>();
 	private SparseArray<Intent> mPausedRequests = new SparseArray<Intent>();
 	
 	private Set<OperationServiceListener> mListeners = com.robotoworks.mechanoid.internal.util.Collections.newSetFromMap(new WeakHashMap<OperationServiceListener, Boolean>());
@@ -486,5 +486,9 @@ public class OperationServiceBridge {
 		}
 		
 		return true;
+	}
+
+	public static SparseArray<Intent> getPendingRequests() {
+	    return mPendingRequests;
 	}
 }


### PR DESCRIPTION
With this I'm able to scan the ops queue.
For example when I'm triggered by loader and refresh the map only on last operation.
Means:
my MapActivity generates a lot of long-running operations

```
operation1 (latitude/longitude) <-- running
operation2 (latitude/longitude)
operation3 (latitude/longitude)
operation4 (latitude/longitude)
operation5 (latitude/longitude) <- next mandatory
```

when operation1 is finished, operation1 can now itself skip following unneeded operation2, operation3, operation4.
Next is now operation5 

this makes here no sense

```
operation webCall(double lat, double lon, int radiusKm) unique (lat, lon)
```
